### PR TITLE
Remove hardcoded file output parameter

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -5,5 +5,3 @@ runs:
   image: 'docker://zdenekdrahos/phpqa:v1.23.3'
   args:
     - phpqa
-    - --output
-    - file


### PR DESCRIPTION
Every project can decide whether a file output may be used or not using the `.phpqa.yml` file.